### PR TITLE
Add Route method to tree

### DIFF
--- a/_example/moderate-myself/main.go
+++ b/_example/moderate-myself/main.go
@@ -41,9 +41,13 @@ func main() {
 	selectedID := 0
 
 	m := corde.NewMux(pk, appID, token)
-	m.Command("cmd/list", list(m, g))
-	m.Button("cmd/list/next", btnNext(m, g, mu, &selectedID))
-	m.Button("cmd/list/remove", btnRemove(m, g, mu, &selectedID))
+	m.Route("cmd", func(m *corde.Mux) {
+		m.Route("list", func(m *corde.Mux) {
+			m.Command("", list(m, g))
+			m.Button("next", btnNext(m, g, mu, &selectedID))
+			m.Button("remove", btnRemove(m, g, mu, &selectedID))
+		})
+	})
 
 	if err := m.RegisterCommand(command, g); err != nil {
 		log.Fatalln("error registering command: ", err)

--- a/_example/todo/main.go
+++ b/_example/todo/main.go
@@ -75,12 +75,16 @@ func main() {
 	}
 
 	m := corde.NewMux(pk, appID, token)
-	m.Command("todo/add", t.addHandler)
-	m.Command("todo/rm", t.removeHandler)
-	m.Command("todo/list", t.listHandler)
+	m.Route("todo", func(m *corde.Mux) {
+		m.Command("add", t.addHandler)
+		m.Command("rm", t.removeHandler)
+		m.Command("list", t.listHandler)
+	})
 
 	g := corde.GuildOpt(corde.SnowflakeFromString(os.Getenv("DISCORD_GUILD_ID")))
-	m.BulkRegisterCommand(commands, g)
+	if err := m.BulkRegisterCommand(commands, g); err != nil {
+		log.Fatalln(err)
+	}
 
 	if err := m.ListenAndServe(":8070"); err != nil {
 		log.Fatalln(err)

--- a/go.mod
+++ b/go.mod
@@ -5,3 +5,5 @@ go 1.18
 require github.com/karitham/go-genial v0.2.0
 
 require github.com/akrennmair/go-radix v1.0.1-0.20211215212324-49d05194b0a3
+
+require github.com/matryer/is v1.4.0

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,6 @@
 github.com/akrennmair/go-radix v1.0.1-0.20211215212324-49d05194b0a3 h1:cC+usowX2qUArGE+BauZSn2qCxHqBXhBmA3CkFMULBg=
 github.com/akrennmair/go-radix v1.0.1-0.20211215212324-49d05194b0a3/go.mod h1:YPJ4C/zdh9bNuHZCccyEX3xnq7vtjMw2Lu8RgBohgRk=
-github.com/armon/go-radix v1.0.0 h1:F4z6KzEeeQIMeLFa97iZU6vupzoecKdU5TX24SNppXI=
-github.com/armon/go-radix v1.0.0/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=
 github.com/karitham/go-genial v0.2.0 h1:AHb2iBbzOBS8kc3E0QiZR3Z6txdBS9u0IDhGGketskE=
 github.com/karitham/go-genial v0.2.0/go.mod h1:HBN0CvV0hsPCMegF7wvmUK3l8OnNzs8XVxt350NI5eE=
+github.com/matryer/is v1.4.0 h1:sosSmIWwkYITGrxZ25ULNDeKiMNzFSr4V/eqBQP0PeE=
+github.com/matryer/is v1.4.0/go.mod h1:8I/i5uYgLzgsgEloJE1U6xx5HkBQpAZvepWuujKwMRU=

--- a/router_test.go
+++ b/router_test.go
@@ -1,0 +1,41 @@
+package corde
+
+import (
+	"github.com/matryer/is"
+	"testing"
+)
+
+func TestRoute(t *testing.T) {
+	assert := is.New(t)
+
+	m := NewMux("", Snowflake(0), "")
+
+	m.Route("foo", func(m *Mux) {
+		m.Route("bar", func(m *Mux) {
+			m.Command("baz", nil)
+		})
+	})
+	m.Route("/foo", func(m *Mux) {
+		m.Route("/bar", func(m *Mux) {
+			m.Command("/baz", nil)
+		})
+	})
+	m.Route("foo/", func(m *Mux) {
+		m.Route("bar/", func(m *Mux) {
+			m.Command("baz/", nil)
+		})
+	})
+	m.Route("/foo/", func(m *Mux) {
+		m.Route("/bar/", func(m *Mux) {
+			m.Command("/baz/", nil)
+		})
+	})
+	m.Command("foo/bar/baz", nil)
+
+	var commands []string
+	for cmd := range m.routes.command.ToMap() {
+		commands = append(commands, cmd)
+	}
+
+	assert.Equal(commands, []string{"foo/bar/baz"}) // There should only be a single command on the router
+}


### PR DESCRIPTION
As you can see in the examples, this allows users to group common parts of a router. 
The indentation is nice for visual grouping, and it can help reduce re-typing the common prefix.