### PR TITLE
Add some format helpers

### DIFF
--- a/format/format.go
+++ b/format/format.go
@@ -1,0 +1,60 @@
+// Package format https://discord.com/developers/docs/reference#message-formatting
+package format
+
+import (
+	"fmt"
+	"time"
+)
+
+// User returns a user mention
+func User(id string) string {
+	return fmt.Sprintf("<@%s>", id)
+}
+
+// UserNick returns a user (nickname) mention
+func UserNick(id string) string {
+	return fmt.Sprintf("<@!%s>", id)
+}
+
+// Channel returns a channel mention
+func Channel(id string) string {
+	return fmt.Sprintf("<#%s>", id)
+}
+
+// Role returns a role mention
+func Role(id string) string {
+	return fmt.Sprintf("<@&%s>", id)
+}
+
+// Emoji returns a custom emoji
+func Emoji(name, id string) string {
+	return fmt.Sprintf("<:%s:%s>", name, id)
+}
+
+// AnimatedEmoji returns a custom animated emoji
+func AnimatedEmoji(name, id string) string {
+	return fmt.Sprintf("<a:%s:%s>", name, id)
+}
+
+// Timestamp returns a timestamp
+func Timestamp(ts time.Time) string {
+	return TimestampStyled(ts, TimestampShortDateTime)
+}
+
+// TimestampStyle https://discord.com/developers/docs/reference#message-formatting-timestamp-styles
+type TimestampStyle string
+
+const (
+	TimestampShortTime     TimestampStyle = "t"
+	TimestampLongTime      TimestampStyle = "T"
+	TimestampShortDate     TimestampStyle = "d"
+	TimestampLongDate      TimestampStyle = "D"
+	TimestampShortDateTime TimestampStyle = "f"
+	TimestampLongDateTime  TimestampStyle = "F"
+	TimestampRelative      TimestampStyle = "R"
+)
+
+// TimestampStyled returns a styled timestamp
+func TimestampStyled(ts time.Time, style TimestampStyle) string {
+	return fmt.Sprintf("<t:%d:%s>", ts.Unix(), style)
+}

--- a/format/format_test.go
+++ b/format/format_test.go
@@ -1,0 +1,72 @@
+package format
+
+import (
+	"fmt"
+	"testing"
+	"time"
+)
+
+const testID = "1234567890"
+
+func TestFormat(t *testing.T) {
+	tt := []struct {
+		Name     string
+		Fmt      func(string) string
+		Expected string
+	}{
+		{
+			Name:     "User",
+			Fmt:      User,
+			Expected: fmt.Sprintf("<@%s>", testID),
+		},
+		{
+			Name:     "UserNick",
+			Fmt:      UserNick,
+			Expected: fmt.Sprintf("<@!%s>", testID),
+		},
+		{
+			Name:     "Channel",
+			Fmt:      Channel,
+			Expected: fmt.Sprintf("<#%s>", testID),
+		},
+		{
+			Name:     "Role",
+			Fmt:      Role,
+			Expected: fmt.Sprintf("<@&%s>", testID),
+		},
+		{
+			Name: "Emoji",
+			Fmt: func(s string) string {
+				return Emoji("test", s)
+			},
+			Expected: fmt.Sprintf("<:test:%s>", testID),
+		},
+		{
+			Name: "AnimatedEmoji",
+			Fmt: func(s string) string {
+				return AnimatedEmoji("test", s)
+			},
+			Expected: fmt.Sprintf("<a:test:%s>", testID),
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.Name, func(t *testing.T) {
+			out := tc.Fmt(testID)
+			if out != tc.Expected {
+				t.Logf("Incorrect Format\nExpected: %s\n     Got: %s\n", tc.Expected, out)
+				t.Fail()
+			}
+		})
+	}
+}
+
+func TestTimestamp(t *testing.T) {
+	now := time.Now()
+	expected := fmt.Sprintf("<t:%d:f>", now.Unix())
+	got := Timestamp(now)
+	if got != expected {
+		t.Logf("Expected: %s\n     Got: %s\n", expected, got)
+		t.Fail()
+	}
+}

--- a/format/format_test.go
+++ b/format/format_test.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"testing"
 	"time"
+
+	"github.com/matryer/is"
 )
 
 const testID = "1234567890"
@@ -52,21 +54,18 @@ func TestFormat(t *testing.T) {
 
 	for _, tc := range tt {
 		t.Run(tc.Name, func(t *testing.T) {
+			assert := is.New(t)
 			out := tc.Fmt(testID)
-			if out != tc.Expected {
-				t.Logf("Incorrect Format\nExpected: %s\n     Got: %s\n", tc.Expected, out)
-				t.Fail()
-			}
+			assert.Equal(out, tc.Expected) // Formatted should match expected
 		})
 	}
 }
 
 func TestTimestamp(t *testing.T) {
+	assert := is.New(t)
+
 	now := time.Now()
 	expected := fmt.Sprintf("<t:%d:f>", now.Unix())
 	got := Timestamp(now)
-	if got != expected {
-		t.Logf("Expected: %s\n     Got: %s\n", expected, got)
-		t.Fail()
-	}
+	assert.Equal(got, expected) // Formatted should match expected
 }


### PR DESCRIPTION
This PR adds some formatting helpers from https://discord.com/developers/docs/reference#message-formatting

I think these will be useful for responding to interactions, etc. without having to look up reference docs every time.