### PR TITLE
Allow strings and snowflakes for format

### DIFF
--- a/0_example/todo/todo.go
+++ b/0_example/todo/todo.go
@@ -55,7 +55,7 @@ func (t *todo) listHandler(w corde.ResponseWriter, _ *corde.Interaction) {
 			Description(func() string {
 				s, i := &strings.Builder{}, 1
 				for k, v := range t.list {
-					s.WriteString(fmt.Sprintf("%d. %s: %s - %s\n", i, k, v.value, format.User(v.user.String())))
+					s.WriteString(fmt.Sprintf("%d. %s: %s - %s\n", i, k, v.value, format.User(v.user)))
 					i++
 				}
 				return s.String()

--- a/format/format.go
+++ b/format/format.go
@@ -4,35 +4,42 @@ package format
 import (
 	"fmt"
 	"time"
+
+	"github.com/Karitham/corde"
 )
 
+// ID is a Discord ID, either in string form or corde.Snowflake form
+type ID interface {
+	~string | corde.Snowflake
+}
+
 // User returns a user mention
-func User(id string) string {
+func User[T ID](id T) string {
 	return fmt.Sprintf("<@%s>", id)
 }
 
 // UserNick returns a user (nickname) mention
-func UserNick(id string) string {
+func UserNick[T ID](id T) string {
 	return fmt.Sprintf("<@!%s>", id)
 }
 
 // Channel returns a channel mention
-func Channel(id string) string {
+func Channel[T ID](id T) string {
 	return fmt.Sprintf("<#%s>", id)
 }
 
 // Role returns a role mention
-func Role(id string) string {
+func Role[T ID](id T) string {
 	return fmt.Sprintf("<@&%s>", id)
 }
 
 // Emoji returns a custom emoji
-func Emoji(name, id string) string {
+func Emoji[T ID](name string, id T) string {
 	return fmt.Sprintf("<:%s:%s>", name, id)
 }
 
 // AnimatedEmoji returns a custom animated emoji
-func AnimatedEmoji(name, id string) string {
+func AnimatedEmoji[T ID](name string, id T) string {
 	return fmt.Sprintf("<a:%s:%s>", name, id)
 }
 

--- a/format/format_test.go
+++ b/format/format_test.go
@@ -5,57 +5,110 @@ import (
 	"testing"
 	"time"
 
+	"github.com/Karitham/corde"
+
 	"github.com/matryer/is"
 )
 
-const testID = "1234567890"
+const testIDString = "1234567890"
 
-func TestFormat(t *testing.T) {
-	tt := []struct {
-		Name     string
-		Fmt      func(string) string
-		Expected string
-	}{
+var testIDSnowflake = corde.SnowflakeFromString(testIDString)
+
+type testcase[T ID] struct {
+	Name     string
+	Fmt      func(T) string
+	Expected string
+}
+
+func TestFormatString(t *testing.T) {
+	tt := []testcase[string]{
 		{
 			Name:     "User",
-			Fmt:      User,
-			Expected: fmt.Sprintf("<@%s>", testID),
+			Fmt:      User[string],
+			Expected: fmt.Sprintf("<@%s>", testIDString),
 		},
 		{
 			Name:     "UserNick",
-			Fmt:      UserNick,
-			Expected: fmt.Sprintf("<@!%s>", testID),
+			Fmt:      UserNick[string],
+			Expected: fmt.Sprintf("<@!%s>", testIDString),
 		},
 		{
 			Name:     "Channel",
-			Fmt:      Channel,
-			Expected: fmt.Sprintf("<#%s>", testID),
+			Fmt:      Channel[string],
+			Expected: fmt.Sprintf("<#%s>", testIDString),
 		},
 		{
 			Name:     "Role",
-			Fmt:      Role,
-			Expected: fmt.Sprintf("<@&%s>", testID),
+			Fmt:      Role[string],
+			Expected: fmt.Sprintf("<@&%s>", testIDString),
 		},
 		{
 			Name: "Emoji",
 			Fmt: func(s string) string {
 				return Emoji("test", s)
 			},
-			Expected: fmt.Sprintf("<:test:%s>", testID),
+			Expected: fmt.Sprintf("<:test:%s>", testIDString),
 		},
 		{
 			Name: "AnimatedEmoji",
 			Fmt: func(s string) string {
 				return AnimatedEmoji("test", s)
 			},
-			Expected: fmt.Sprintf("<a:test:%s>", testID),
+			Expected: fmt.Sprintf("<a:test:%s>", testIDString),
 		},
 	}
 
 	for _, tc := range tt {
 		t.Run(tc.Name, func(t *testing.T) {
 			assert := is.New(t)
-			out := tc.Fmt(testID)
+			out := tc.Fmt(testIDString)
+			assert.Equal(out, tc.Expected) // Formatted should match expected
+		})
+	}
+}
+
+func TestFormatSnowflake(t *testing.T) {
+	tt := []testcase[corde.Snowflake]{
+		{
+			Name:     "User",
+			Fmt:      User[corde.Snowflake],
+			Expected: fmt.Sprintf("<@%s>", testIDString),
+		},
+		{
+			Name:     "UserNick",
+			Fmt:      UserNick[corde.Snowflake],
+			Expected: fmt.Sprintf("<@!%s>", testIDString),
+		},
+		{
+			Name:     "Channel",
+			Fmt:      Channel[corde.Snowflake],
+			Expected: fmt.Sprintf("<#%s>", testIDString),
+		},
+		{
+			Name:     "Role",
+			Fmt:      Role[corde.Snowflake],
+			Expected: fmt.Sprintf("<@&%s>", testIDString),
+		},
+		{
+			Name: "Emoji",
+			Fmt: func(s corde.Snowflake) string {
+				return Emoji("test", s)
+			},
+			Expected: fmt.Sprintf("<:test:%s>", testIDString),
+		},
+		{
+			Name: "AnimatedEmoji",
+			Fmt: func(s corde.Snowflake) string {
+				return AnimatedEmoji("test", s)
+			},
+			Expected: fmt.Sprintf("<a:test:%s>", testIDString),
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.Name, func(t *testing.T) {
+			assert := is.New(t)
+			out := tc.Fmt(testIDSnowflake)
 			assert.Equal(out, tc.Expected) // Formatted should match expected
 		})
 	}

--- a/interaction-opt.gen.go
+++ b/interaction-opt.gen.go
@@ -2,7 +2,6 @@
 
 package corde
 
-
 // String returns the option with key k of type string
 func (o OptionsInteractions) String(k string) string {
 	var v string


### PR DESCRIPTION
Resolves #12 

I think this works fine, as most of the time the type can be inferred and so the funcs would usually not end up any messier than before.