### PR TITLE
Use InteractionRequest for incoming Interactions, attach request.Context

### DIFF
--- a/0_example/bongo/main.go
+++ b/0_example/bongo/main.go
@@ -38,7 +38,7 @@ func main() {
 	}
 }
 
-func bongoHandler(w corde.ResponseWriter, _ *corde.Interaction) {
+func bongoHandler(w corde.ResponseWriter, _ *corde.InteractionRequest) {
 	resp, err := http.Get("https://cdn.discordapp.com/emojis/745709799890747434.gif?size=128")
 	if err != nil {
 		w.Respond(corde.NewResp().Content("couldn't retrieve bongo").Ephemeral())

--- a/0_example/moderate-myself/commands_test.go
+++ b/0_example/moderate-myself/commands_test.go
@@ -15,7 +15,7 @@ func Test_list(t *testing.T) {
 	tests := []struct {
 		name        string
 		mock        owmock.ResponseWriterMock
-		interaction *corde.Interaction
+		interaction *corde.InteractionRequest
 	}{
 		{
 			name: "list",
@@ -30,7 +30,7 @@ func Test_list(t *testing.T) {
 					}
 				},
 			},
-			interaction: &corde.Interaction{},
+			interaction: &corde.InteractionRequest{},
 		},
 	}
 	for _, tt := range tests {
@@ -45,8 +45,8 @@ func Test_btnNext(t *testing.T) {
 	tests := []struct {
 		name        string
 		mock        owmock.ResponseWriterMock
-		interaction *corde.Interaction
-		fn          func(corde.ResponseWriter, *corde.Interaction)
+		interaction *corde.InteractionRequest
+		fn          func(corde.ResponseWriter, *corde.InteractionRequest)
 	}{
 		{
 			name: "btn next",
@@ -63,7 +63,7 @@ func Test_btnNext(t *testing.T) {
 					}
 				},
 			},
-			interaction: &corde.Interaction{},
+			interaction: &corde.InteractionRequest{},
 			fn:          btnNext(&corde.Mux{Client: http.DefaultClient}, corde.GuildOpt(0), &sync.Mutex{}, &selectedID),
 		},
 	}

--- a/0_example/moderate-myself/main.go
+++ b/0_example/moderate-myself/main.go
@@ -68,8 +68,8 @@ var delBtn = corde.Component{
 	Emoji:    &corde.Emoji{Name: "🗑️"},
 }
 
-func list(m *corde.Mux, g func(*corde.CommandsOpt)) func(corde.ResponseWriter, *corde.Interaction) {
-	return func(w corde.ResponseWriter, _ *corde.Interaction) {
+func list(m *corde.Mux, g func(*corde.CommandsOpt)) func(corde.ResponseWriter, *corde.InteractionRequest) {
+	return func(w corde.ResponseWriter, _ *corde.InteractionRequest) {
 		w.Respond(corde.NewResp().
 			ActionRow(nextBtn).
 			Ephemeral().
@@ -78,8 +78,8 @@ func list(m *corde.Mux, g func(*corde.CommandsOpt)) func(corde.ResponseWriter, *
 	}
 }
 
-func btnNext(m *corde.Mux, g func(*corde.CommandsOpt), mu *sync.Mutex, selectedID *int) func(corde.ResponseWriter, *corde.Interaction) {
-	return func(w corde.ResponseWriter, _ *corde.Interaction) {
+func btnNext(m *corde.Mux, g func(*corde.CommandsOpt), mu *sync.Mutex, selectedID *int) func(corde.ResponseWriter, *corde.InteractionRequest) {
+	return func(w corde.ResponseWriter, _ *corde.InteractionRequest) {
 		mu.Lock()
 		defer mu.Unlock()
 		commands, err := m.GetCommands(g)
@@ -102,8 +102,8 @@ func btnNext(m *corde.Mux, g func(*corde.CommandsOpt), mu *sync.Mutex, selectedI
 	}
 }
 
-func btnRemove(m *corde.Mux, g func(*corde.CommandsOpt), mu *sync.Mutex, selectedID *int) func(corde.ResponseWriter, *corde.Interaction) {
-	return func(w corde.ResponseWriter, _ *corde.Interaction) {
+func btnRemove(m *corde.Mux, g func(*corde.CommandsOpt), mu *sync.Mutex, selectedID *int) func(corde.ResponseWriter, *corde.InteractionRequest) {
+	return func(w corde.ResponseWriter, _ *corde.InteractionRequest) {
 		mu.Lock()
 		defer mu.Unlock()
 		commands, err := m.GetCommands(g)

--- a/0_example/todo/todo.go
+++ b/0_example/todo/todo.go
@@ -19,7 +19,7 @@ type todoItem struct {
 	value string
 }
 
-func (t *todo) autoCompleteNames(w corde.ResponseWriter, i *corde.Interaction) {
+func (t *todo) autoCompleteNames(w corde.ResponseWriter, _ *corde.InteractionRequest) {
 	t.mu.Lock()
 	defer t.mu.Unlock()
 
@@ -36,7 +36,7 @@ func (t *todo) autoCompleteNames(w corde.ResponseWriter, i *corde.Interaction) {
 	w.Autocomplete(resp)
 }
 
-func (t *todo) addHandler(w corde.ResponseWriter, i *corde.Interaction) {
+func (t *todo) addHandler(w corde.ResponseWriter, i *corde.InteractionRequest) {
 	value := i.Data.Options.String("value")
 	name := i.Data.Options.String("name")
 
@@ -56,7 +56,7 @@ func (t *todo) addHandler(w corde.ResponseWriter, i *corde.Interaction) {
 	w.Respond(corde.NewResp().Contentf("Successfully added %s", name).Ephemeral())
 }
 
-func (t *todo) listHandler(w corde.ResponseWriter, _ *corde.Interaction) {
+func (t *todo) listHandler(w corde.ResponseWriter, _ *corde.InteractionRequest) {
 	t.mu.Lock()
 	defer t.mu.Unlock()
 
@@ -82,7 +82,7 @@ func (t *todo) listHandler(w corde.ResponseWriter, _ *corde.Interaction) {
 	)
 }
 
-func (t *todo) removeHandler(w corde.ResponseWriter, i *corde.Interaction) {
+func (t *todo) removeHandler(w corde.ResponseWriter, i *corde.InteractionRequest) {
 	t.mu.Lock()
 	defer t.mu.Unlock()
 

--- a/sample-component_test.go
+++ b/sample-component_test.go
@@ -11,11 +11,11 @@ import (
 )
 
 func TestComponentInteraction(t *testing.T) {
-	is := is.New(t)
+	assert := is.New(t)
 	pub, _ := owmock.GenerateKeys()
 	mux := corde.NewMux(pub, 0, "")
 
-	mux.Button("click_one", func(w corde.ResponseWriter, _ *corde.Interaction) {
+	mux.Button("click_one", func(w corde.ResponseWriter, _ *corde.InteractionRequest) {
 		w.Respond(&corde.InteractionRespData{
 			Content: "Hello World!",
 		})
@@ -30,13 +30,13 @@ func TestComponentInteraction(t *testing.T) {
 
 	s := httptest.NewServer(mux.Handler())
 	respPost, err := owmock.NewWithClient(s.URL, s.Client()).Post(SampleComponent)
-	is.NoErr(err)
+	assert.NoErr(err)
 
 	respV := &owmock.InteractionResponse{}
 	err = json.Unmarshal(respPost, respV)
-	is.NoErr(err)
+	assert.NoErr(err)
 
-	is.Equal(expect, respV)
+	assert.Equal(expect, respV)
 }
 
 const SampleComponent = `{


### PR DESCRIPTION
A new type for incoming interactions, also attaches the `http.Request.Context` to it.

This helps us not muddle up the Discord types for the sake of the router.