### PR TITLE
Add example compliance checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,3 +21,9 @@ jobs:
         run: go test -race -v ./...
       - name: Run Vet
         run: go vet ./...
+      - name: Example Compliance
+        run: |
+          go build ./0_example/bongo
+          go build ./0_example/moderate-myself
+          go build ./0_example/nft
+          go build ./0_example/todo


### PR DESCRIPTION
Build the examples during CI to ensure we never end up with broken examples.